### PR TITLE
Build every push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,21 @@
+on:
+    workflow_dispatch:
+    push:
+  
+  name: Quarto build
+  
+  jobs:
+    build:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: write
+      steps:
+        - name: Check out repository
+          uses: actions/checkout@v4
+  
+        - name: Set up Quarto
+          uses: quarto-dev/quarto-actions/setup@v2
+  
+        - name: Render
+          uses: quarto-dev/quarto-actions/render@v2
+  

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,9 @@
 on:
     workflow_dispatch:
     push:
+    pull_request:
+      branches: 
+        - main
   
 name: Quarto build
   

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,9 @@ on:
     workflow_dispatch:
     push:
   
-  name: Quarto build
+name: Quarto build
   
-  jobs:
+jobs:
     build:
       runs-on: ubuntu-latest
       permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
     build:
       runs-on: ubuntu-latest
       permissions:
-        contents: write
+        contents: read
       steps:
         - name: Check out repository
           uses: actions/checkout@v4


### PR DESCRIPTION
gives a chance to notice mistakes before they are in main.

Sadly, I have not found a way to make warnings also be treated as errors.